### PR TITLE
Update book links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Nu Contributor Book
+
+You can via it live at [www.nushell.sh/contributor-book/](https://www.nushell.sh/contributor-book/)
+
 This is a draft of the Nushell Contributor Book. It attempts to cover the basics of how Nu works internally, to better enable contributors to have a solid understanding of Nu and how best to contribute.
 
 Please see the directory for each language for a full list of available chapters.

--- a/books.md
+++ b/books.md
@@ -3,10 +3,10 @@ title: Other Books
 layout: books
 ---
 
-# [Nu Book](https://book.nushell.sh)
+# [Nu Book](https://www.nushell.sh/book/)
 
-You can read our [book](https://book.nushell.sh) to lern more about the core concepts behind Nu. It covers the basic and contains a lot of examples which will help you to have an easy start. 
+You can read our [book](https://www.nushell.sh/book/) to lern more about the core concepts behind Nu. It covers the basic and contains a lot of examples which will help you to have an easy start. 
 
-# [Cookbook](https://github.com/nushell/cookbook)
+# [Cookbook](https://www.nushell.sh/cookbook/)
 
-[Nu Cookbook](https://github.com/nushell/cookbook) is a collection of examples to help you get the most out of using Nushell. It offers multiple ways of expressing the same pipelines so you can become familiar with all the commands.
+[Nu Cookbook](https://www.nushell.sh/cookbook/) is a collection of examples to help you get the most out of using Nushell. It offers multiple ways of expressing the same pipelines so you can become familiar with all the commands.

--- a/en/README.md
+++ b/en/README.md
@@ -1,4 +1,7 @@
-# Nushell Contributor Book
+---
+layout: books
+title: Nushell Contributor Book
+---
 
 The goals of this book are to help developers understand how Nu is designed and developed, to make it easier to jump in and contribute.
 

--- a/en/introduction.md
+++ b/en/introduction.md
@@ -7,7 +7,7 @@ link_prev: /
 link_next: /en/philosophy.html
 ---
 
-Hello and welcome to the Nushell Contributor Book.  Nushell, or Nu as its often called, is a modern shell written in Rust. You can learn more about Nu and how to use in the [Nu book](https://book.nushell.sh).  In this book, we'll be looking at how to contribute to the Nu project itself, how Nu's code is organized, and the core concepts behind its design.
+Hello and welcome to the Nushell Contributor Book.  Nushell, or Nu as its often called, is a modern shell written in Rust. You can learn more about Nu and how to use in the [Nu book](https://www.nushell.sh/book/).  In this book, we'll be looking at how to contribute to the Nu project itself, how Nu's code is organized, and the core concepts behind its design.
 
 Contributing to Nu will require at least some basic programmer experience, and it's helpful to have some experience with Rust. That said, we've had people contribute to Nu who have never before written a line of Rust before writing their submission. If you are interested in contributing, there's a growing community of people who would like to help you succeed.
 

--- a/es/README.md
+++ b/es/README.md
@@ -1,4 +1,8 @@
-# El manual de Nu para contribuyentes
+---
+layout: books
+title: El manual de Nu para contribuyentes
+---
+
 El libro de trabajo en progreso para el manual de Nu para contribuyentes
 
 Actualmente disponibles:

--- a/es/introduccion.md
+++ b/es/introduccion.md
@@ -6,7 +6,7 @@ next: Filosofía
 link_prev: /
 link_next: /es/filosofia.html
 ---
-Hola y bienvenido al manual de Nushell para contribuyentes. Nushell, o Nu como se lo llama a menudo, es un shell moderno escrito en Rust. Para más información sobre Nu y cómo usarlo puedes aprenderlo en [El libro Nu](https://book.nushell.sh/es). En este manual, veremos cómo contribuir al proyecto Nu, cómo está organizado el código, y los conceptos centrales detrás de su diseño.
+Hola y bienvenido al manual de Nushell para contribuyentes. Nushell, o Nu como se lo llama a menudo, es un shell moderno escrito en Rust. Para más información sobre Nu y cómo usarlo puedes aprenderlo en [El libro Nu](https://www.nushell.sh/book/es/). En este manual, veremos cómo contribuir al proyecto Nu, cómo está organizado el código, y los conceptos centrales detrás de su diseño.
 
 Contribuir a Nu requerirá al menos algo de experiencia básica en programación, y es útil tener algo de experiencia con Rust. Dicho esto, hemos tenido personas que han contribuído a Nu sin antes haber escrito una línea de Rust antes de que escribieran su primera contribución. Si te interesa contribuir, hay una comunidad creciente de personas con deseos de ayudarte a tener éxito.
 


### PR DESCRIPTION
PR updates the links to the books.

I changed the language specific README files too to have a correctly formatted page on https://www.nushell.sh/contributor-book/es/ . It doesn't look correct on the local preview but if you follow the link it shows the README file which is a bit weird :)
Maybe we should have this as our first book page and not start with the installation guide