### PR TITLE
en/commands.md: Fix broken links under Jekyll

### DIFF
--- a/en/commands.md
+++ b/en/commands.md
@@ -11,7 +11,7 @@ Commands are the building blocks for pipelines in Nu. They do the action of the 
 
 ## Internal commands
 
-All commands inside of Nu, including plugins, are internal commands. Internal commands communicate with each other using streams of [Tagged<Value>](https://github.com/nushell/nushell/blob/d30c40b40ebfbb411a503ad7c7bceae8029c6689/crates/nu-source/src/meta.rs#L91) and [ShellError](https://github.com/nushell/nushell/blob/main/crates/nu-errors/src/lib.rs#L179)
+All commands inside of Nu, including plugins, are internal commands. Internal commands communicate with each other using streams of [Tagged&lt;Value&gt;](https://github.com/nushell/nushell/blob/d30c40b40ebfbb411a503ad7c7bceae8029c6689/crates/nu-source/src/meta.rs#L91) and [ShellError](https://github.com/nushell/nushell/blob/main/crates/nu-errors/src/lib.rs#L179).
 
 ### Signature
 


### PR DESCRIPTION
This is a minor fix to the Markdown. GitHub renders the existing Markdown correctly but Jekyll doesn't, as you can see on https://www.nushell.sh/contributor-book/en/commands.html:
![image](https://user-images.githubusercontent.com/463856/91502661-7d5ca100-e87d-11ea-883a-7abd859290c6.png)

I also snuck in a period at the end of the sentence.