### PR TITLE
Fix outdated plugins.md

### DIFF
--- a/en/plugins.md
+++ b/en/plugins.md
@@ -281,12 +281,15 @@ def print_good_response(response):
     sys.stdout.flush()
 
 
-def get_length(string_value):
-    string_len = len(string_value["item"]["Primitive"]["String"])
-    int_item = {"Primitive": {"Int": string_len}}
-    int_value = string_value
-    int_value["item"] = int_item
-    return int_value
+def get_length(arg):
+    tag = arg["tag"]
+    int_value = {"Primitive": {
+        "Int": str(len(arg["value"]["Primitive"]["String"]))
+    }}
+    return {
+        "tag": tag,
+        "value": int_value,
+    }
 
 
 for line in fileinput.input():
@@ -339,12 +342,15 @@ From there, we look at what method is being invoked. For this plugin, there are 
 The other three methods -- begin_filter, filter, and end_filter -- all work together to do the work of filtering the data coming in. As this plugin will work 1-to-1 with each bit of data, turning strings into their string lengths, we do most of our work in the `filter` method. The 'end_filter' method here tells us it's time for the plugin to shut down, so we go ahead and break out of the loop.
 
 ```python
-def get_length(string_value):
-    string_len = len(string_value["item"]["Primitive"]["String"])
-    int_item = {"Primitive": {"Int": string_len}}
-    int_value = string_value
-    int_value["item"] = int_item
-    return int_value
+def get_length(arg):
+    tag = arg["tag"]
+    int_value = {"Primitive": {
+        "Int": str(len(arg["value"]["Primitive"]["String"]))
+    }}
+    return {
+        "tag": tag,
+        "value": int_value,
+    }
 ```
 
 The work of filtering is done by the `get_length` function. Here, we assume we're given strings (we could make this more robust in the future and return errors otherwise), and then we extract the string we're given. From there, we measure the length of the string and create a new `Int` value for that length.

--- a/en/plugins.md
+++ b/en/plugins.md
@@ -17,16 +17,16 @@ The second stage is the actual doing of work. Here the plugins are sent either a
 
 ## Discovery
 
-Nu discovers plugins by checking all directories available in the current PATH.
+Nu discovers plugins by checking all directories specified as `plugin_dirs` in [config.toml](https://github.com/nushell/nushell/blob/main/docs/sample_config/config.toml) file (in `~/.config/nu/` on Linux)
 In each directory, Nu is looking for executable files that match the pattern `nu_plugin_*` where `*` is a minimum of one alphanumeric character.
 On Windows, this has a similar pattern of `nu_plugin_*.exe` or `nu_plugin_*.bat`.
 
 Once a matching file has been discovered, Nu will invoke the file and pass to it the first JSON-RPC command: config.
 Config replies with the signature of the plugin, which is identical to the signature commands use.
 
-Nu continues in this way until it has traveled across all directories in the path.
+Nu continues in this way until it has traveled across all directories in `plugin_dirs`.
 
-After it has traversed the path, it will look in two more directories: the target/debug and the target/release directories. It will pick one or the other depending whether Nu was compiled in debug mode or release mode, respectively. This allows for easier testing of plugins during development.
+After it has traversed `plugin_dirs`, it will look in two more directories: the target/debug and the target/release directories. It will pick one or the other depending whether Nu was compiled in debug mode or release mode, respectively. This allows for easier testing of plugins during development.
 
 ## Creating a plugin (in Rust)
 


### PR DESCRIPTION
- Placing plugin in a `$PATH` directory does not work. Must put in `plugin_dirs` in config.toml
- The dictionary key `"item"` is changed to `"value"`
- Must change `"Int": len(...)` to `"Int": str(len(...))`
- Improve the logic of `get_length`, just add `tag` key instead of shallow-copying the input.